### PR TITLE
do not show anything in the timesheets table if the type is user

### DIFF
--- a/src/app/timesheets/_presenters/components/TimesheetsTable/_presenters/components/TableCell/index.tsx
+++ b/src/app/timesheets/_presenters/components/TimesheetsTable/_presenters/components/TableCell/index.tsx
@@ -26,9 +26,6 @@ const TableCell = ({
   onChange: onChangeCell,
   assignments,
 }: Props) => {
-  if (!userId) {
-    return null;
-  }
   const formattedDate = dayjs(date).format("YYYY-MM-DD");
   const timeEntry = timeEntries.find(
     (entry) =>
@@ -45,6 +42,9 @@ const TableCell = ({
     onChangeCell,
   });
 
+  if (!userId) {
+    return null;
+  }
   const canAddHours = !!assignments.find((assignment) => {
     const compareDate = new Date(date).setHours(0, 0, 0, 0);
     const startDate = new Date(assignment.startDate).setHours(0, 0, 0, 0);


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**

This pull request adds a null check for the `userId` prop in `TableCell` and formats the code with an extra new line.

**Key Points**

1. Introduces null check for `userId` prop in `TableCell`.
2. Formats code with an additional new line. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>